### PR TITLE
server status check and public ip issue

### DIFF
--- a/src/main/java/org/dasein/cloud/openstack/nova/os/compute/NovaServer.java
+++ b/src/main/java/org/dasein/cloud/openstack/nova/os/compute/NovaServer.java
@@ -1266,11 +1266,9 @@ public class NovaServer implements VirtualMachineSupport {
                             }
                             if( addr != null ) {
                                 if( isPublicIpAddress(addr) ) {
-                                    System.out.println("Check : IpAddress : " + addr.getIpAddress() + " is public.");
                                 	pub.add(addr);
                                 }
                                 else {
-                                    System.out.println("Check : IpAddress : " + addr.getIpAddress() + " is private.");
                                     priv.add(addr);
                                 }
                             }


### PR DESCRIPTION
Some server's status in JSON response from the cloud was 

"status":"ACTIVE(image_snapshot)",

The '.equals' check did not recognize this status and changed it to PENDING. Hence changed it to check with '.startsWith'.

And public IPs are labeled as private IP's in the JSON response from the cloud.

"addresses":{
        "private":[
    .   {
        "version":4,
        "addr":"10.4.193.142"
    .   },
    .   {
        "version":4,
        "addr":"15.185.98.74"
    .   },
    .   {
        "version":4,
        "addr":"15.185.121.48"
    .   }
        ]
},
I noticed that this issue was handled in 2013.04 by a method that checks whether the IP is public or not. So i added similar method and separated private and public IPs.
