### PR TITLE
Fix for handling rackspace server firewalls.

### DIFF
--- a/src/main/java/org/dasein/cloud/openstack/nova/os/compute/NovaServer.java
+++ b/src/main/java/org/dasein/cloud/openstack/nova/os/compute/NovaServer.java
@@ -1304,20 +1304,26 @@ public class NovaServer extends AbstractVMSupport {
             }
             vm.setPlatform(p);
         }
-        Iterable<String> fwIds = listFirewalls(vm.getProviderVirtualMachineId(), server);
-        int count = 0;
-
-        //noinspection UnusedDeclaration
-        for( String id : fwIds ) {
-            count++;
+        if (provider.getProviderName().equalsIgnoreCase("RACKSPACE")){
+            //Rackspace does not support the concept for firewalls in servers
+        	vm.setProviderFirewallIds(null);
         }
-        String[] ids = new String[count];
-        int i = 0;
+        else{
+            Iterable<String> fwIds = listFirewalls(vm.getProviderVirtualMachineId(), server);
+            int count = 0;
 
-        for( String id : fwIds ) {
-            ids[i++] = id;
+            //noinspection UnusedDeclaration
+            for( String id : fwIds ) {
+                count++;
+            }
+            String[] ids = new String[count];
+            int i = 0;
+
+            for( String id : fwIds ) {
+                ids[i++] = id;
+            }
+            vm.setProviderFirewallIds(ids);
         }
-        vm.setProviderFirewallIds(ids);
         return vm;
     }
 


### PR DESCRIPTION
I could not find firewalls/security group information for servers in the Rackspace api documentation. It looks like they use software firewalls. I am not sure if this is the right way to handle this issue but it seems to work. 
