### PR TITLE
Switched snapshot owner to AccountNumber from TenantId.

### DIFF
--- a/src/main/java/org/dasein/cloud/openstack/nova/os/compute/CinderSnapshot.java
+++ b/src/main/java/org/dasein/cloud/openstack/nova/os/compute/CinderSnapshot.java
@@ -68,6 +68,10 @@ public class CinderSnapshot extends AbstractSnapshotSupport {
         return ((NovaOpenStack)getProvider()).getAuthenticationContext().getTenantId();
     }
 
+    private @Nonnull String getAccountNumber() throws CloudException, InternalException {
+        return getProvider().getContext().getAccountNumber();
+    }
+
     private @Nonnull String getResource() {
         // hp seems to be used the regular grizzly resource
         // return (((NovaOpenStack)getProvider()).isHP() ? "/os-snapshots" : "/snapshots");
@@ -395,7 +399,7 @@ public class CinderSnapshot extends AbstractSnapshotSupport {
             snapshot.setCurrentState(currentState);
             snapshot.setDescription(description);
             snapshot.setName(name);
-            snapshot.setOwner(getTenantId());
+            snapshot.setOwner(getAccountNumber());
             snapshot.setProviderSnapshotId(snapshotId);
             snapshot.setRegionId(regionId);
             snapshot.setSizeInGb(size);


### PR DESCRIPTION
This PR switched the Owner of Snapshots from the TenantId to the accountNumber. I believe that this is causing FB 4795. Amazon uses the accountNumber for this value, and DCM compares this value to the accountNumber in its cloud_account table to determine whether a snapshot is owned by a user (or has been shared from another user).

Looking back at previous versions of dasein-cloud-openstack (like 2013.02) it seems that the accountNumber was used as the owner in the past, so I'm not sure why this was changed. Was there a particular reason for that?
