### PR TITLE
[bugzid:4792] Added a missing remove method to NovaImage

### DIFF
--- a/src/main/java/org/dasein/cloud/openstack/nova/os/compute/NovaImage.java
+++ b/src/main/java/org/dasein/cloud/openstack/nova/os/compute/NovaImage.java
@@ -388,6 +388,11 @@ public class NovaImage extends AbstractImageSupport {
     }
 
     @Override
+    public void remove(@Nonnull String providerImageId) throws CloudException, InternalException {
+        remove(providerImageId, false);
+    }
+
+    @Override
     public void remove(@Nonnull String providerImageId, boolean checkState) throws CloudException, InternalException {
         APITrace.begin(getProvider(), "Image.remove");
         try {


### PR DESCRIPTION
The `remove(@Nonnull String providerImageId)` method is used by DCM, and doesn't seem to be implemented in dasein-cloud-openstack. This PR adds support for it by calling the previously implemented `remove(@Nonnull String providerImageId, boolean checkState)` method.
