### PR TITLE
Switched to getting the accountNumber from the ProviderContext.

### DIFF
--- a/src/main/java/org/dasein/cloud/openstack/nova/os/AbstractMethod.java
+++ b/src/main/java/org/dasein/cloud/openstack/nova/os/AbstractMethod.java
@@ -153,7 +153,7 @@ public abstract class AbstractMethod {
         try {
             String accessPublic = null;
             String accessPrivate = null;
-            String account = null;
+            String account = provider.getContext().getAccountNumber();
             try {
                 List<ContextRequirements.Field> fields = provider.getContextRequirements().getConfigurableValues();
                 for(ContextRequirements.Field f : fields ) {
@@ -161,9 +161,6 @@ public abstract class AbstractMethod {
                         byte[][] keyPair = (byte[][])provider.getContext().getConfigurationValue(f);
                         accessPublic = new String(keyPair[0], "utf-8");
                         accessPrivate = new String(keyPair[1], "utf-8");
-                    }
-                    else if (f.type.equals(ContextRequirements.FieldType.TEXT)) {
-                        account = (String)provider.getContext().getConfigurationValue(f);
                     }
                 }
             }
@@ -513,7 +510,7 @@ public abstract class AbstractMethod {
         try {
             String accessPublic = null;
             String accessPrivate = null;
-            String account = null;
+            String account = provider.getContext().getAccountNumber();
             try {
                 List<ContextRequirements.Field> fields = provider.getContextRequirements().getConfigurableValues();
                 for(ContextRequirements.Field f : fields ) {
@@ -521,9 +518,6 @@ public abstract class AbstractMethod {
                         byte[][] keyPair = (byte[][])provider.getContext().getConfigurationValue(f);
                         accessPublic = new String(keyPair[0], "utf-8");
                         accessPrivate = new String(keyPair[1], "utf-8");
-                    }
-                    else if (f.type.equals(ContextRequirements.FieldType.TEXT)) {
-                        account = (String)provider.getContext().getConfigurationValue(f);
                     }
                 }
             }
@@ -719,7 +713,7 @@ public abstract class AbstractMethod {
         }
         String accessPublic = null;
         String accessPrivate = null;
-        String accountNum = null;
+        String accountNum = provider.getContext().getAccountNumber();
         try {
             List<ContextRequirements.Field> fields = provider.getContextRequirements().getConfigurableValues();
             for(ContextRequirements.Field f : fields ) {
@@ -727,9 +721,6 @@ public abstract class AbstractMethod {
                     byte[][] keyPair = (byte[][])provider.getContext().getConfigurationValue(f);
                     accessPublic = new String(keyPair[0], "utf-8");
                     accessPrivate = new String(keyPair[1], "utf-8");
-                }
-                else if (f.type.equals(ContextRequirements.FieldType.TEXT)) {
-                    accountNum = (String)provider.getContext().getConfigurationValue(f);
                 }
             }
         }

--- a/src/main/java/org/dasein/cloud/openstack/nova/os/NovaOpenStack.java
+++ b/src/main/java/org/dasein/cloud/openstack/nova/os/NovaOpenStack.java
@@ -145,8 +145,7 @@ public class NovaOpenStack extends AbstractCloud {
     public @Nonnull
     ContextRequirements getContextRequirements() {
         return new ContextRequirements(
-                new ContextRequirements.Field("apiKey", "The API Keypair", ContextRequirements.FieldType.KEYPAIR, ContextRequirements.Field.ACCESS_KEYS, true),
-                new ContextRequirements.Field("accountNumber", "The account/tenant id", ContextRequirements.FieldType.TEXT, ContextRequirements.Field.ACCESS_KEYS)
+                new ContextRequirements.Field("apiKey", "The API Keypair", ContextRequirements.FieldType.KEYPAIR, ContextRequirements.Field.ACCESS_KEYS, true)
         );
     }
     


### PR DESCRIPTION
There is already a built-in accountNumber in ProviderContext, so there
is no need to specify it as a ContextRequirement.
